### PR TITLE
refactor(uniapp): 在 start 方法中显示日志面板

### DIFF
--- a/src/core/uniapp/process.ts
+++ b/src/core/uniapp/process.ts
@@ -20,6 +20,7 @@ export class UniappDebugProcess extends EventEmitter {
   }
 
   public async start(args: UniappRuntimeArgs) {
+    this.logger.show(true);
     this.logger.info("uniapp-run process start ....");
     this.logger.info(`HBuilderX path: ${this.config.HBuilderPath}`);
     this.logger.info(`WorkPath: ${args.uniInputDir}`);

--- a/src/core/uniapp/process.ts
+++ b/src/core/uniapp/process.ts
@@ -20,7 +20,7 @@ export class UniappDebugProcess extends EventEmitter {
   }
 
   public async start(args: UniappRuntimeArgs) {
-    this.logger.show(true);
+    this.logger.show();
     this.logger.info("uniapp-run process start ....");
     this.logger.info(`HBuilderX path: ${this.config.HBuilderPath}`);
     this.logger.info(`WorkPath: ${args.uniInputDir}`);


### PR DESCRIPTION
- 通过调用 this.logger.show(true) 方法来确保日志面板可见，避免点击构建运行后以为没有运行